### PR TITLE
change decode value validation to empty

### DIFF
--- a/src/data/BasicPrimitiveDataTypeHandler.php
+++ b/src/data/BasicPrimitiveDataTypeHandler.php
@@ -133,7 +133,7 @@ abstract class BasicPrimitiveDataTypeHandler extends BasicDataTypeHandler
     \codename\parquet\format\SchemaElement $tse,
     $encoded
   ) {
-    if ($encoded === null) return null;
+    if (empty($encoded)) return null;
 
     $ms = fopen('php://memory', 'r+');
     fwrite($ms, $encoded);

--- a/src/data/concrete/DateTimeOffsetDataTypeHandler.php
+++ b/src/data/concrete/DateTimeOffsetDataTypeHandler.php
@@ -270,7 +270,7 @@ class DateTimeOffsetDataTypeHandler extends BasicPrimitiveDataTypeHandler
     \codename\parquet\format\SchemaElement $tse,
     $encoded
   ) {
-    if ($encoded === null) return null;
+    if (empty($encoded)) return null;
     $ms = fopen('php://memory', 'r+');
     fwrite($ms, $encoded);
     $reader = BinaryReader::createInstance($ms);

--- a/src/data/concrete/StringDataTypeHandler.php
+++ b/src/data/concrete/StringDataTypeHandler.php
@@ -187,7 +187,7 @@ class StringDataTypeHandler extends BasicDataTypeHandler
     \codename\parquet\format\SchemaElement $tse,
     $encoded
   ) {
-    if ($encoded === null) return null;
+    if (empty($encoded)) return null;
 
     $ms = fopen('php://memory', 'r+');
     fwrite($ms, $encoded);


### PR DESCRIPTION
I assume the empty encoded value can be in all the data types. 
So I made the change for all the types.