### PR TITLE
fixed an error with the column name "0".

### DIFF
--- a/src/file/ThriftFooter.php
+++ b/src/file/ThriftFooter.php
@@ -211,7 +211,10 @@ class ThriftFooter {
           array_merge(
             $path ?? [], // Fallback to empty array as path
             $se->path ?? [ $se->name ] // NOTE: fallback to array-ified $se->name
-          )
+          ),
+          function ($v) {
+              return !empty($v) || $v == "0";
+          }
         )
       ));
 


### PR DESCRIPTION
When reading a file with indexed column names: 0, 1, 2, ...

Get error: 
```
In ParquetRowGroupReader.php line 100:
                                  
  '' does not exist in this file  
```

The error occurs because when defining the path, the array_filter function throws the normal value "0" equating it to NULL.

`array_filter` function without callback:


```php

$entry = [
    0 => 'foo',
    1 => false,
    2 => -1,
    3 => null,
    4 => '',
    5 => '0',
    6 => 0,
];

print_r(array_filter($entry));
```

The above example will output:
```
Array
(
    [0] => foo
    [2] => -1
)
```



