### PR TITLE
Adds support for zstd compressed parquet files

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,7 +26,7 @@ jobs:
           - 8.4
         phpunit-versions: ['latest']
     env:
-      extensions: mbstring, intl, xml, gmp, bcmath, snappy-kjdev/php-ext-snappy@0.2.2
+      extensions: mbstring, intl, xml, gmp, bcmath, snappy-kjdev/php-ext-snappy@0.2.2, zstd
       key: extcache-v1
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "packaged/thrift": "^0.16.0"
     },
     "suggest" : {
-      "ext-snappy" : "Install/compile snappy extension to get support for snappy compression reading/writing"
+      "ext-snappy" : "Install/compile snappy extension to get support for snappy compression reading/writing",
+      "ext-zstd" : "Install/compile zstd extension to get support for zstd compression reading/writing"
     },
     "autoload": {
         "psr-4": {

--- a/src/CompressionMethod.php
+++ b/src/CompressionMethod.php
@@ -6,4 +6,5 @@ class CompressionMethod
   public const None = 0;
   public const Gzip = 1;
   public const Snappy = 2;
+  public const Zstd = 6;
 }

--- a/src/ZstdStreamWrapper.php
+++ b/src/ZstdStreamWrapper.php
@@ -10,13 +10,26 @@ use Exception;
 class ZstdStreamWrapper implements StreamWrapperInterface, MarkWriteFinishedInterface
 {
   /**
-   * The internal default compression level
-   * 1 = Lowest compression, highest speed
-   * 6 = ZLIB/Gzip common default (usually)
-   * 9 = 'Highest' compression, lowest speed
+   * Default zstd compression level used when writing pages.
+   *
+   * zstd_compress accepts levels 1..22 (and negative values down to
+   * ZSTD_minCLevel() for "fast" mode — roughly -131072..-1, ratio drops
+   * sharply in exchange for very fast writes).
+   *
+   *   1   = fastest write, weakest ratio
+   *   3   = upstream zstd default
+   *   9   = chosen here: good ratio for parquet's per-page chunks without
+   *         materially slowing writes (per benchmarking)
+   *  15+ = noticeably better ratios on this workload, but write cost
+   *         starts to climb (level 22 is ~30% slower than 9)
+   *
+   * Per-page compression means zstd can't build a dictionary across the
+   * file, so very high levels show diminishing returns vs. one-shot
+   * compression of the same data.
+   *
    * @var int
    */
-  const DEFAULT_COMPRESSION_LEVEL = 6;
+  const DEFAULT_COMPRESSION_LEVEL = 9;
 
   /**
    * [createWrappedStream description]
@@ -68,10 +81,13 @@ class ZstdStreamWrapper implements StreamWrapperInterface, MarkWriteFinishedInte
   protected $leaveOpen = false;
 
   /**
-   * GZ/ZLIB compression level
+   * Zstd compression level (1..22, or negative for fast mode).
+   * Overwritten in stream_open from the stream context; this initializer
+   * is only the fallback if the wrapper is somehow constructed without a
+   * context, and matches {@see DEFAULT_COMPRESSION_LEVEL}.
    * @var int
    */
-  protected $compressionLevel = 9;
+  protected $compressionLevel = self::DEFAULT_COMPRESSION_LEVEL;
 
   /**
    * @inheritDoc
@@ -265,7 +281,7 @@ class ZstdStreamWrapper implements StreamWrapperInterface, MarkWriteFinishedInte
       // Passed via stream option
       $this->leaveOpen = stream_context_get_options($this->context)['zstd']['leave_open'] ?? false;
       $this->compressionMode = stream_context_get_options($this->context)['zstd']['compression_mode'] ?? null;
-      $this->compressionLevel = stream_context_get_options($this->context)['zstd']['compression_level'] ?? 6; // Default fallback: 6 (common default)
+      $this->compressionLevel = stream_context_get_options($this->context)['zstd']['compression_level'] ?? static::DEFAULT_COMPRESSION_LEVEL;
 
       if($this->compressionMode === null) {
         throw new Exception('Compression mode undefined');

--- a/src/ZstdStreamWrapper.php
+++ b/src/ZstdStreamWrapper.php
@@ -1,0 +1,419 @@
+<?php
+namespace codename\parquet;
+
+use Exception;
+
+
+/**
+ * [ZstdStreamWrapper description]
+ */
+class ZstdStreamWrapper implements StreamWrapperInterface, MarkWriteFinishedInterface
+{
+  /**
+   * The internal default compression level
+   * 1 = Lowest compression, highest speed
+   * 6 = ZLIB/Gzip common default (usually)
+   * 9 = 'Highest' compression, lowest speed
+   * @var int
+   */
+  const DEFAULT_COMPRESSION_LEVEL = 6;
+
+  /**
+   * [createWrappedStream description]
+   * @param resource  $stream           [description]
+   * @param string    $mode             [read-write-mode]
+   * @param int       $compressionMode  [compression mode]
+   * @param bool      $leaveOpen        [whether to leave underlying stream open on closing of this stream - by default, this is true for this type of stream]
+   * @return resource
+   */
+  public static function createWrappedStream($stream, $mode, int $compressionMode, bool $leaveOpen = true) {
+    $context = stream_context_create([
+      'zstd' => [
+        'leave_open'        => $leaveOpen,
+        'compression_mode'  => $compressionMode,
+        'compression_level'  => static::DEFAULT_COMPRESSION_LEVEL,
+      ]
+    ]);
+    return fopen('zstd://'.$stream, $mode, false, $context);
+  }
+
+  /**
+   * [public description]
+   * @var resource
+   */
+  public $context;
+
+  /**
+   * [register description]
+   */
+  public static function register(): void {
+    $wrapperExists = in_array("zstd", stream_get_wrappers());
+    if ($wrapperExists) {
+        // stream_wrapper_unregister("gzip");
+    } else {
+      stream_wrapper_register('zstd', static::class);
+    }
+  }
+
+  /**
+   * inner stream
+   * @var resource
+   */
+  protected $parent = null;
+
+  /**
+   * Whether to leave the underlying stream open on stream close
+   * @var bool
+   */
+  protected $leaveOpen = false;
+
+  /**
+   * GZ/ZLIB compression level
+   * @var int
+   */
+  protected $compressionLevel = 9;
+
+  /**
+   * @inheritDoc
+   */
+  public function __construct()
+  {
+    // throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function __destruct()
+  {
+    // throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function dir_closedir(): bool
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function dir_opendir(string $path, int $options): bool
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function dir_readdir(): string
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function mkdir(string $path, int $mode, int $options): bool
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function rename(string $path_from, string $path_to): bool
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function dir_rewinddir(): bool
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function rmdir(string $path, int $options): bool
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_cast(int $cast_as)
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function url_stat(string $path, int $flags): array
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function unlink(string $path): bool
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_write(string $data): int
+  {
+    return fwrite($this->ms, $data);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_truncate(int $new_size): bool
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_tell(): int
+  {
+    return ftell($this->ms);
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_stat(): array
+  {
+    return fstat($this->parent);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_set_option(int $option, int $arg1, int $arg2): bool
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_seek(int $offset, int $whence = SEEK_SET): bool
+  {
+    return fseek($this->ms, $offset, $whence) === 0;
+    // return true;
+    // throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_read(int $count): string
+  {
+    return fread($this->ms, $count);
+  }
+
+  protected static $prefix = 'zstd://';
+
+  /**
+   * [protected description]
+   * @var int
+   */
+  protected $compressionMode;
+
+  /**
+   * [protected description]
+   * @var resource
+   */
+  protected $ms;
+
+  /**
+   * Flag to track if compression has been written
+   * @var bool
+   */
+  protected $finishedForWriting = false;
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_open(
+    string $path,
+    string $mode,
+    int $options,
+    ?string &$opened_path
+  ): bool {
+    if(strpos($path, 'Resource id #') === strlen(static::$prefix)) {
+      // stringified resource identifier, get as handle via get_resource
+      $resourceId = explode('#', $path)[1];
+      $this->parent = get_resources()[$resourceId];
+
+      // Passed via stream option
+      $this->leaveOpen = stream_context_get_options($this->context)['zstd']['leave_open'] ?? false;
+      $this->compressionMode = stream_context_get_options($this->context)['zstd']['compression_mode'] ?? null;
+      $this->compressionLevel = stream_context_get_options($this->context)['zstd']['compression_level'] ?? 6; // Default fallback: 6 (common default)
+
+      if($this->compressionMode === null) {
+        throw new Exception('Compression mode undefined');
+      }
+
+      if($this->compressionMode === static::MODE_COMPRESS) {
+        $this->ms = fopen('php://memory', 'r+');
+      } else {
+        $this->ms = $this->decompressFromStream($this->parent);
+      }
+    } else {
+      // non-resource, manually fopen?
+      throw new Exception('unsupported');
+    }
+
+    return true;
+  }
+
+  /**
+   * [MODE_DECOMPRESS description]
+   * @var int
+   */
+  const MODE_DECOMPRESS = 0;
+
+  /**
+   * [MODE_COMPRESS description]
+   * @var int
+   */
+  const MODE_COMPRESS = 1;
+
+  /**
+   * [decompressFromStream description]
+   * @param  resource   $source [description]
+   * @return resource        [description]
+   */
+  protected function decompressFromStream($source)
+  {
+    $content = stream_get_contents($source);
+    $decompressed = zstd_uncompress($content);
+    $handle = fopen('php://memory', 'r+');
+    fwrite($handle, $decompressed);
+    fflush($handle);
+    fseek($handle, 0);
+    return $handle;
+  }
+
+  /**
+   * Writes out the final, compressed stream
+   */
+  protected function writeCompressedStream(): void {
+    if($this->finishedForWriting) return;
+
+    if($this->compressionMode === static::MODE_COMPRESS) {
+      $uncompressedLength = fstat($this->ms)['size'];
+
+      $compressed = zstd_compress(stream_get_contents($this->ms, $uncompressedLength, 0), $this->compressionLevel);
+
+      $compressedSize = strlen($compressed);
+      fseek($this->parent, 0);
+      fwrite($this->parent, $compressed);
+      fflush($this->parent);
+      //
+      // TODO: some error handling
+      //
+    }
+
+    $this->finishedForWriting = true;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function MarkWriteFinished(): void
+  {
+    $this->writeCompressedStream();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_metadata(
+    string $path,
+    int $option,
+    $value
+  ): bool {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_lock(int $operation): bool
+  {
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_flush(): bool
+  {
+    //
+    // TODO: check, what we should do here...
+    // We might flush $this->ms
+    //
+    return false;
+    throw new \LogicException('Not implemented'); // TODO
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_eof(): bool
+  {
+    return feof($this->ms); // ? IDEA: maybe depending on mode?
+    // return false;
+    // throw new \LogicException('Not implemented'); // TODO
+    // return feof($this->parent);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function stream_close(): void
+  {
+    //
+    // Write out (compress!) on close
+    // As long as not closed, we delay compression until closing of this stream.
+    //
+    $this->writeCompressedStream();
+
+    // NOT SURE ABOUT THIS THING.
+    if(!$this->leaveOpen) {
+      if(is_resource($this->parent)) {
+        fclose($this->parent);
+      } else {
+        // Resource/stream already closed/disposed
+        // QUESTION: Should we throw an exception?
+        // throw new Exception('Inner stream already closed or freed');
+      }
+    }
+
+    // QUESTION should we do this here?
+    // We should kick out the reference for the GC to work...
+    // NOTE/SEE: https://stackoverflow.com/questions/28195655/php-garbage-collection-when-using-static-method-to-create-instance
+    // Different behaviour regarding resources in PHP than regular variables/members.
+    // This seems to work for now, but I'm unsure about using WeakRef (pecl ext) or WeakReference (PHP 7.4+) in favor.
+    //
+    $this->parent = null;
+  }
+}

--- a/src/data/DataFactory.php
+++ b/src/data/DataFactory.php
@@ -20,6 +20,7 @@ class DataFactory
     CompressionMethod::None => CompressionCodec::UNCOMPRESSED,
     CompressionMethod::Gzip => CompressionCodec::GZIP,
     CompressionMethod::Snappy => CompressionCodec::SNAPPY,
+    CompressionMethod::Zstd => CompressionCodec::ZSTD,
   ];
 
   /**

--- a/src/file/DataStreamFactory.php
+++ b/src/file/DataStreamFactory.php
@@ -7,6 +7,7 @@ use codename\parquet\GapStreamWrapper;
 use codename\parquet\CompressionMethod;
 use codename\parquet\GzipStreamWrapper;
 use codename\parquet\SnappyInMemoryStreamWrapper;
+use codename\parquet\ZstdStreamWrapper;
 
 use codename\parquet\format\CompressionCodec;
 
@@ -21,6 +22,7 @@ class DataStreamFactory
     CompressionCodec::UNCOMPRESSED  => 'none',
     CompressionCodec::GZIP          => 'gzip',
     CompressionCodec::SNAPPY        => 'snappy',
+    CompressionCodec::ZSTD          => 'zstd',
   ];
 
   /**
@@ -30,6 +32,7 @@ class DataStreamFactory
     GapStreamWrapper::register();
     GzipStreamWrapper::register();
     SnappyInMemoryStreamWrapper::register();
+    ZstdStreamWrapper::register();
   }
 
   /**
@@ -56,6 +59,11 @@ class DataStreamFactory
           $dest = SnappyInMemoryStreamWrapper::createWrappedStream($nakedStream, 'r+', SnappyInMemoryStreamWrapper::MODE_COMPRESS);
           $leaveNakedOpen = false;
            break;
+
+        case CompressionMethod::Zstd:
+          $dest = ZstdStreamWrapper::createWrappedStream($nakedStream, 'r+', ZstdStreamWrapper::MODE_COMPRESS);
+          $leaveNakedOpen = false;
+          break;
 
         case CompressionMethod::None:
            $dest = $nakedStream;
@@ -145,6 +153,15 @@ class DataStreamFactory
         if($uncompressedData === false) {
           throw new \Exception('Decompression error (snappy)');
         }
+        $data = $uncompressedData;
+        break;
+
+      case 'zstd':
+        $uncompressedData = zstd_uncompress($data);
+        if($uncompressedData === false) {
+          throw new \Exception('Decompression error (zstd)');
+        }
+
         $data = $uncompressedData;
         break;
 

--- a/tests/IssueTest.php
+++ b/tests/IssueTest.php
@@ -10,13 +10,10 @@ class IssueTest extends TestBase
    * Tests a specific issue of parquet-dotnet
    * to be or not to be present in our package
    * @see https://github.com/aloneguid/parquet-dotnet/issues/81
+   * @requires extension snappy
    */
   public function testParquetDotnetIssue81(): void
   {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
-
     $reader = new ParquetReader($this->openTestFile('issues/parquet-dotnet_81_floats.parquet'));
     $dataColumns = $reader->ReadEntireRowGroup();
     $values = $dataColumns[0]->getData();

--- a/tests/ParquetReaderTest.php
+++ b/tests/ParquetReaderTest.php
@@ -5,6 +5,12 @@ namespace codename\parquet\tests;
 use Exception;
 
 use codename\parquet\ParquetReader;
+use codename\parquet\ParquetWriter;
+use codename\parquet\CompressionMethod;
+
+use codename\parquet\data\Schema;
+use codename\parquet\data\DataField;
+use codename\parquet\data\DataColumn;
 
 use codename\parquet\exception\ArgumentNullException;
 
@@ -228,11 +234,9 @@ final class ParquetReaderTest extends TestBase
   //
   /**
    * [testReadBitPackedAtPageBoundary description]
+   * @requires extension snappy
    */
   public function testReadBitPackedAtPageBoundary(): void {
-    if(!extension_loaded('snappy')) {
-      static::markTestSkipped('ext-snappy unavailable');
-    }
     $reader = new ParquetReader($this->openTestFile('special/multi_page_bit_packed_near_page_border.parquet'));
     $columns = $reader->ReadEntireRowGroup();
     $data = $columns[0]->getData();
@@ -355,11 +359,9 @@ final class ParquetReaderTest extends TestBase
 
   /**
    * [testReadEmptyColumn description]
+   * @requires extension snappy
    */
   public function testReadEmptyColumn(): void {
-    if(!extension_loaded('snappy')) {
-      static::markTestSkipped('ext-snappy unavailable');
-    }
     $reader = new ParquetReader($this->openTestFile('emptycolumn.parquet'));
     $columns = $reader->ReadEntireRowGroup();
     $col0 = $columns[0]->getData();
@@ -368,6 +370,77 @@ final class ParquetReaderTest extends TestBase
     foreach($col0 as $value) {
       $this->assertNull($value);
     }
+  }
+
+  /**
+   * Test reading zstd-compressed parquet file
+   * @requires extension zstd
+   */
+  public function testReadZstdCompressedFile(): void {
+    // First, write a zstd-compressed file
+    $ms = fopen('php://memory', 'r+');
+    $id = DataField::createFromType('id', 'integer');
+    $name = DataField::createFromType('name', 'string');
+    $value = DataField::createFromType('value', 'double');
+
+    $writer = new ParquetWriter(new Schema([$id, $name, $value]), $ms, null, false, CompressionMethod::Zstd);
+    $rg = $writer->CreateRowGroup();
+    $rg->WriteColumn(new DataColumn($id, [ 1, 2, 3, 4, 5 ]));
+    $rg->WriteColumn(new DataColumn($name, [ 'Alice', 'Bob', 'Charlie', 'David', 'Eve' ]));
+    $rg->WriteColumn(new DataColumn($value, [ 1.1, 2.2, 3.3, 4.4, 5.5 ]));
+    $rg->finish();
+    $writer->finish();
+
+    // Now read it back
+    fseek($ms, 0);
+    $reader = new ParquetReader($ms);
+    $columns = $reader->ReadEntireRowGroup();
+
+    $this->assertEquals([ 1, 2, 3, 4, 5 ], $columns[0]->getData());
+    $this->assertEquals([ 'Alice', 'Bob', 'Charlie', 'David', 'Eve' ], $columns[1]->getData());
+    $this->assertEquals([ 1.1, 2.2, 3.3, 4.4, 5.5 ], $columns[2]->getData());
+  }
+
+  /**
+   * Test reading zstd-compressed parquet file with multiple row groups
+   * @requires extension zstd
+   */
+  public function testReadZstdCompressedMultipleRowGroups(): void {
+    $ms = fopen('php://memory', 'r+');
+    $id = DataField::createFromType('id', 'integer');
+
+    $writer = new ParquetWriter(new Schema([$id]), $ms, null, false, CompressionMethod::Zstd);
+
+    // Write first row group
+    $rg = $writer->CreateRowGroup();
+    $rg->WriteColumn(new DataColumn($id, [ 1, 2, 3 ]));
+    $rg->finish();
+
+    // Write second row group
+    $rg = $writer->CreateRowGroup();
+    $rg->WriteColumn(new DataColumn($id, [ 4, 5, 6 ]));
+    $rg->finish();
+
+    // Write third row group
+    $rg = $writer->CreateRowGroup();
+    $rg->WriteColumn(new DataColumn($id, [ 7, 8, 9 ]));
+    $rg->finish();
+
+    $writer->finish();
+
+    // Read back and verify
+    fseek($ms, 0);
+    $reader = new ParquetReader($ms);
+    $this->assertEquals(3, $reader->getRowGroupCount());
+
+    $rg = $reader->OpenRowGroupReader(0);
+    $this->assertEquals([ 1, 2, 3 ], $rg->ReadColumn($id)->getData());
+
+    $rg = $reader->OpenRowGroupReader(1);
+    $this->assertEquals([ 4, 5, 6 ], $rg->ReadColumn($id)->getData());
+
+    $rg = $reader->OpenRowGroupReader(2);
+    $this->assertEquals([ 7, 8, 9 ], $rg->ReadColumn($id)->getData());
   }
 
 }

--- a/tests/ParquetWriterTest.php
+++ b/tests/ParquetWriterTest.php
@@ -6,6 +6,7 @@ use Exception;
 
 use codename\parquet\ParquetReader;
 use codename\parquet\ParquetWriter;
+use codename\parquet\CompressionMethod;
 
 use codename\parquet\data\Schema;
 use codename\parquet\data\DataField;
@@ -288,11 +289,74 @@ final class ParquetWriterTest extends TestBase
 
     $rg = $reader->OpenRowGroupReader(0);
     $col = $rg->ReadColumn($id);
-    
+
     $this->assertEquals(4, $rg->getRowCount());
 
     $rg = $reader->OpenRowGroupReader(1);
     $this->assertEquals(2, $rg->getRowCount());
+  }
+
+  /**
+   * Test writing and reading data with Zstd compression
+   * @requires extension zstd
+   */
+  public function testWriteReadWithZstdCompression(): void {
+    $ms = fopen('php://memory', 'r+');
+    $id = DataField::createFromType('id', 'integer');
+    $name = DataField::createFromType('name', 'string');
+
+    //write with zstd compression
+    $writer = new ParquetWriter(new Schema([$id, $name]), $ms, null, false, CompressionMethod::Zstd);
+
+    $rg = $writer->CreateRowGroup();
+    $rg->WriteColumn(new DataColumn($id, [ 1, 2, 3, 4 ]));
+    $rg->WriteColumn(new DataColumn($name, [ 'Alice', 'Bob', 'Charlie', 'David' ]));
+    $rg->finish();
+
+    $rg = $writer->CreateRowGroup();
+    $rg->WriteColumn(new DataColumn($id, [ 5, 6 ]));
+    $rg->WriteColumn(new DataColumn($name, [ 'Eve', 'Frank' ]));
+    $rg->finish();
+
+    $writer->finish();
+
+    //read back
+    fseek($ms, 0);
+    $reader = new ParquetReader($ms);
+    $this->assertEquals(6, $reader->getThriftMetadata()->num_rows);
+
+    $rg = $reader->OpenRowGroupReader(0);
+    $this->assertEquals(4, $rg->getRowCount());
+    $this->assertEquals([ 1, 2, 3, 4 ], $rg->ReadColumn($id)->getData());
+    $this->assertEquals([ 'Alice', 'Bob', 'Charlie', 'David' ], $rg->ReadColumn($name)->getData());
+
+    $rg = $reader->OpenRowGroupReader(1);
+    $this->assertEquals(2, $rg->getRowCount());
+    $this->assertEquals([ 5, 6 ], $rg->ReadColumn($id)->getData());
+    $this->assertEquals([ 'Eve', 'Frank' ], $rg->ReadColumn($name)->getData());
+  }
+
+  /**
+   * Test writing and reading nullable columns with Zstd compression
+   * @requires extension zstd
+   */
+  public function testWriteReadNullableColumnWithZstdCompression(): void {
+    $id = DataField::createFromType('id', 'integer');
+    $ms = fopen('php://memory', 'r+');
+
+    $writer = new ParquetWriter(new Schema([$id]), $ms, null, false, CompressionMethod::Zstd);
+    $rg = $writer->CreateRowGroup();
+    $rg->WriteColumn(new DataColumn($id, [ 1, null, 2, null, 3 ]));
+    $rg->finish();
+    $writer->finish();
+
+    fseek($ms, 0);
+
+    $reader = new ParquetReader($ms);
+    $this->assertEquals(1, $reader->getRowGroupCount());
+    $rg = $reader->OpenRowGroupReader(0);
+    $this->assertEquals(5, $rg->getRowCount());
+    $this->assertEquals([ 1, null, 2, null, 3 ], $rg->ReadColumn($id)->getData());
   }
 
 }

--- a/tests/PhpArrayConversionTest.php
+++ b/tests/PhpArrayConversionTest.php
@@ -427,12 +427,9 @@ final class PhpArrayConversionTest extends TestBase
    * Tests reading a file re-written by spark
    * Which originates from a method below
    * @see testSuperComplexWriteRead
+   * @requires extension snappy
    */
   public function testReadSparkRewrittenSuperComplex(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
-
     // Re-written by spark
     $readerSpark = new ParquetReader($this->openTestFile('custom/supercomplex1.spark.parquet'));
     $rgsSpark = $readerSpark->ReadEntireRowGroup();
@@ -502,12 +499,9 @@ final class PhpArrayConversionTest extends TestBase
    * Tests reading a file re-written by spark
    * Which originates from a method below
    * @see testComplexStructsWriteRead
+   * @requires extension snappy
    */
   public function testReadSparkRewrittenComplexStructs(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
-
     // Re-written by spark
     $readerSpark = new ParquetReader($this->openTestFile('custom/complex_structs1.spark.parquet'));
     $rgsSpark = $readerSpark->ReadEntireRowGroup();
@@ -704,12 +698,9 @@ final class PhpArrayConversionTest extends TestBase
 
   /**
    * Tests reading and writing of nested lists
+   * @requires extension snappy
    */
   public function testWriteNestedLists(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
-
     $reader = new ParquetReader($this->openTestFile('nested_lists.snappy.parquet'));
     $rgs = $reader->ReadEntireRowGroup();
     $arrayConverter = new DataColumnsToArrayConverter($reader->schema, $rgs);
@@ -746,12 +737,9 @@ final class PhpArrayConversionTest extends TestBase
 
   /**
    * Tests reading and writing of nested structs
+   * @requires extension snappy
    */
   public function testWriteNestedStructs(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
-
     $reader = new ParquetReader($this->openTestFile('nested_structs.parquet'));
     $rgs = $reader->ReadEntireRowGroup();
     $arrayConverter = new DataColumnsToArrayConverter($reader->schema, $rgs);
@@ -792,12 +780,9 @@ final class PhpArrayConversionTest extends TestBase
   /**
    * Tests reading and writing repeated structs
    * and some specialties
+   * @requires extension snappy
    */
   public function testWriteRepeatedFieldsWithStructs(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
-
     $reader = new ParquetReader($this->openTestFile('repeated_no_annotation.parquet'));
     $rgs = $reader->ReadEntireRowGroup();
     $arrayConverter = new DataColumnsToArrayConverter($reader->schema, $rgs);
@@ -831,12 +816,9 @@ final class PhpArrayConversionTest extends TestBase
 
   /**
    * Tests reading and writing (purely) nested maps
+   * @requires extension snappy
    */
   public function testWriteNestedMaps(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
-
     $reader = new ParquetReader($this->openTestFile('nested_maps.snappy.parquet'));
     $rgs = $reader->ReadEntireRowGroup();
     $arrayConverter = new DataColumnsToArrayConverter($reader->schema, $rgs);
@@ -1503,11 +1485,9 @@ final class PhpArrayConversionTest extends TestBase
    * Subject's field path is split.leftCategoriesOrThreshold.array
    * So there's no intermediary 'list' field
    * But the element itself is repeated
+   * @requires extension snappy
    */
   public function testLegacyListOneArray(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
     $reader = new ParquetReader($this->openTestFile('legacy-list-onearray.parquet'));
     $rgs = $reader->ReadEntireRowGroup();
     $conv = new DataColumnsToArrayConverter($reader->schema, $rgs);
@@ -1540,11 +1520,9 @@ final class PhpArrayConversionTest extends TestBase
 
   /**
    * Tests some list columns w/ and w/o nulls
+   * @requires extension snappy
    */
   public function testListColumns(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
     $reader = new ParquetReader($this->openTestFile('list_columns.parquet'));
     $rgs = $reader->ReadEntireRowGroup();
     $conv = new DataColumnsToArrayConverter($reader->schema, $rgs);
@@ -1558,11 +1536,9 @@ final class PhpArrayConversionTest extends TestBase
 
   /**
    * Tests reading of (purely) nested lists (and their elements)
+   * @requires extension snappy
    */
   public function testNestedLists(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
     $reader = new ParquetReader($this->openTestFile('nested_lists.snappy.parquet'));
     $rgs = $reader->ReadEntireRowGroup();
     $conv = new DataColumnsToArrayConverter($reader->schema, $rgs);
@@ -1585,11 +1561,9 @@ final class PhpArrayConversionTest extends TestBase
 
   /**
    * Tests reading of (purely) nested maps (and their keys/values)
+   * @requires extension snappy
    */
   public function testNestedMaps(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
     $reader = new ParquetReader($this->openTestFile('nested_maps.snappy.parquet'));
     $rgs = $reader->ReadEntireRowGroup();
     $conv = new DataColumnsToArrayConverter($reader->schema, $rgs);
@@ -1606,11 +1580,9 @@ final class PhpArrayConversionTest extends TestBase
 
   /**
    * Tests reading (purely) nested structs (groups) and their fields
+   * @requires extension snappy
    */
   public function testNestedStructs(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
     //
     // NOTE: nested_structs.rust.parquet (the original file)
     // has been compressed using ZSTD (codec 6) and for compatibility,

--- a/tests/Reader/TestDataTest.php
+++ b/tests/Reader/TestDataTest.php
@@ -49,11 +49,9 @@ class TestDataTest extends ParquetCsvComparison
 
   /**
    * [testAllTypesSnappyCompression description]
+   * @requires extension snappy
    */
   public function testAllTypesSnappyCompression(): void {
-    if(!extension_loaded('snappy')) {
-      static::markTestSkipped('ext-snappy unavailable');
-    }
     $this->CompareFiles('types/alltypes', 'snappy', true, [
       'integer',
       'boolean',

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -367,11 +367,9 @@ final class SchemaTest extends TestBase
 
   /**
    * [testBackwardCompatListWithOneArray description]
+   * @requires extension snappy
    */
   public function testBackwardCompatListWithOneArray(): void {
-    if(!extension_loaded('snappy')) {
-      static::markTestSkipped('ext-snappy unavailable');
-    }
     $input = $this->openTestFile('legacy-list-onearray.parquet');
     $reader = new ParquetReader($input);
     $schema = $reader->schema;

--- a/tests/StatisticsTest.php
+++ b/tests/StatisticsTest.php
@@ -56,7 +56,7 @@ final class StatisticsTest extends TestBase
         'Min'           => "one",
         'Max'           => "two" // yes, it is!
       ]),
-      "string2" => new TestDesc([
+      "string3" => new TestDesc([
         'Type'          => 'string', // typeof(string),
         'HasNulls'      => true,
         'Data'          => [ "one", "two", "one", "three", null, "zzz" ],

--- a/tests/VariousTest.php
+++ b/tests/VariousTest.php
@@ -8,11 +8,9 @@ final class VariousTest extends TestBase {
 
   /**
    * [testParquetTestingSingleNan description]
+   * @requires extension snappy
    */
   public function testParquetTestingSingleNan(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
     $reader = new ParquetReader($this->openTestFile('single_nan.parquet'));
     $columns = $reader->ReadEntireRowGroup();
     $this->assertEquals(1, $reader->getThriftMetadata()->num_rows);
@@ -22,11 +20,9 @@ final class VariousTest extends TestBase {
 
   /**
    * [testParquet1402Arrow5322 description]
+   * @requires extension snappy
    */
   public function testParquet1402Arrow5322(): void {
-    if(!extension_loaded('snappy')) {
-      $this->markTestSkipped('ext-snappy unavailable');
-    }
     $this->expectNotToPerformAssertions();
     $reader = new ParquetReader($this->openTestFile('dict-page-offset-zero.parquet'));
     $columns = $reader->ReadEntireRowGroup();

--- a/tests/ZstdTest.php
+++ b/tests/ZstdTest.php
@@ -3,12 +3,13 @@ declare(strict_types=1);
 namespace codename\parquet\tests;
 
 use codename\parquet\StreamHelper;
-use codename\parquet\SnappyInMemoryStreamWrapper;
+use codename\parquet\ZstdStreamWrapper;
 
-final class SnappyTest extends TestBase
+final class ZstdTest extends TestBase
 {
   /**
    * @inheritDoc
+   * @requires extension zstd
    */
   protected function setUp(): void
   {
@@ -16,13 +17,12 @@ final class SnappyTest extends TestBase
   }
 
   /**
-   * Simple test for a working snappy extension
-   * @requires extension snappy
+   * Simple test for a working zstd extension
    */
-  public function testSimpleSnappy(): void {
+  public function testSimpleZstd(): void {
     $sampleString = 'sample';
-    $compressed = snappy_compress($sampleString);
-    $uncompressed = snappy_uncompress($compressed);
+    $compressed = zstd_compress($sampleString);
+    $uncompressed = zstd_uncompress($compressed);
 
     $this->assertNotFalse($compressed); // Assert it's not FALSE (-> erroneous)
     $this->assertEquals($sampleString, $uncompressed);
@@ -30,7 +30,6 @@ final class SnappyTest extends TestBase
 
   /**
    * [testCompressDecompressRandomByteChunks description]
-   * @requires extension snappy
    */
   public function testCompressDecompressRandomByteChunks(): void {
     for ($i=0; $i < 100; $i++) {
@@ -52,11 +51,11 @@ final class SnappyTest extends TestBase
 
     $source = fopen('php://memory', 'r+');
 
-    SnappyInMemoryStreamWrapper::register();
-    $snappy = SnappyInMemoryStreamWrapper::createWrappedStream($source, 'r+', SnappyInMemoryStreamWrapper::MODE_COMPRESS);
+    ZstdStreamWrapper::register();
+    $zstd = ZstdStreamWrapper::createWrappedStream($source, 'r+', ZstdStreamWrapper::MODE_COMPRESS);
 
-    fwrite($snappy, $stage1);
-    StreamHelper::MarkWriteFinished($snappy);
+    fwrite($zstd, $stage1);
+    StreamHelper::MarkWriteFinished($zstd);
 
     // fseek($source, 0); // ?
     $stage2 = stream_get_contents($source, -1, 0);
@@ -65,11 +64,11 @@ final class SnappyTest extends TestBase
     fwrite($source, $stage2);
     fseek($source, 0);
 
-    $snappy = SnappyInMemoryStreamWrapper::createWrappedStream($source, 'r+', SnappyInMemoryStreamWrapper::MODE_DECOMPRESS);
+    $zstd = ZstdStreamWrapper::createWrappedStream($source, 'r+', ZstdStreamWrapper::MODE_DECOMPRESS);
 
     $ms = fopen('php://memory', 'r+');
 
-    stream_copy_to_stream($snappy, $ms);
+    stream_copy_to_stream($zstd, $ms);
 
     $stage3 = stream_get_contents($ms, -1, 0);
 


### PR DESCRIPTION
This replicates much of the functionality that exists via the snappy compression to use zstd compression.