### PR TITLE
Remove dependency on abandoned `pear/math_biginteger` package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "ext-gmp" : "*",
         "ext-bcmath" : "*",
         "ext-zlib": "*",
-        "pear/math_biginteger" : "^1.0",
         "packaged/thrift": "^0.16.0"
     },
     "suggest" : {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" forceCoversAnnotation="false" beStrictAboutCoversAnnotation="false" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" verbose="true">
   <php>
     <ini name="memory_limit" value="512M" />
+    <ini name="date.timezone" value="UTC"/>
   </php>
   <coverage processUncoveredFiles="true">
     <include>

--- a/src/values/primitives/BigDecimal.php
+++ b/src/values/primitives/BigDecimal.php
@@ -2,304 +2,119 @@
 namespace codename\parquet\values\primitives;
 
 use Exception;
-
 use codename\parquet\format\SchemaElement;
 
 class BigDecimal
 {
-  /**
-   * converts a string decimal to binary data
-   * @param [type] $d         [description]
-   * @param [type] $precision [description]
-   * @param [type] $scale     [description]
-   */
-  public static function DecimalToBinary($d, $precision, $scale) {
-    // DecimalValue = d;
-    // Precision = precision;
-    // Scale = scale;
+    /**
+     * converts a string decimal to binary data
+     * @param [type] $d         [description]
+     * @param [type] $precision [description]
+     * @param [type] $scale     [description]
+     */
+    /**
+     * converts a string decimal to binary data
+     */
+    /**
+     * converts a string decimal to binary data
+     */
+    /**
+     * converts a string decimal to binary data
+     */
+    public static function DecimalToBinary($d, $precision, $scale) {
+        $scaleMultiplier = bcpow(10, $scale, 0);
+        $bscaled = gmp_init(bcadd($d, 0, 0));
+        $bscaledNum = gmp_strval($bscaled);
+        $scaled = bcsub($d, $bscaledNum, $precision);
+        $unscaled = bcmul($scaled, $scaleMultiplier, 0);
+        $UnscaledValue = gmp_add(gmp_mul($bscaled, $scaleMultiplier), $unscaled);
 
-    // $debug = $d === "-1";
+        $result = array_fill(0, $bufferSize = static::getBufferSize($precision), null);
 
-    // BigInteger scaleMultiplier = BigInteger.Pow(10, scale);
-    $scaleMultiplier = bcpow(10, $scale, 0);
+        $isNegative = gmp_sign($UnscaledValue) === -1;
+        if ($isNegative) {
+            // Correctly calculate the actual bit length of the absolute value, plus 1 bit for the sign
+            $bitLength = strlen(gmp_strval(gmp_abs($UnscaledValue), 2)) + 1;
+            $byteLength = (int)ceil($bitLength / 8);
+            if ($byteLength === 0) $byteLength = 1;
 
-    // BigInteger bscaled = new BigInteger(d);
-    $bscaled = gmp_init(bcadd($d, 0, 0)); // Trick to strip out the real part, add 0 at 0 precision NOTE: check if we need base 10 for gmp_init?
-    $bscaledNum = gmp_strval($bscaled);
+            // Calculate two's complement for the minimal byte representation length
+            $range = gmp_pow(2, $byteLength * 8);
+            $twoComplement = gmp_add($range, $UnscaledValue);
 
-    // decimal scaled = d - (decimal)bscaled;
-    // only leave fraction?
-    $scaled = bcsub($d, $bscaledNum, $precision); // NOTE: At given precision, we need the fraction part
-    // $scaled = gmp_sub($d, $bscaled);
+            $export = gmp_export($twoComplement, 1, GMP_BIG_ENDIAN | GMP_MSW_FIRST);
+            $export = str_pad($export, $byteLength, "\x00", STR_PAD_LEFT);
+        } else {
+            $export = gmp_export($UnscaledValue, 1, GMP_BIG_ENDIAN | GMP_MSW_FIRST);
+            if ($export === '') $export = "\x00";
+            if (strlen($export) > 0 && (ord($export[0]) & 0x80)) {
+                $export = "\x00" . $export;
+            }
+        }
+        $data = array_reverse(unpack('C*', $export));
+        // ----------------------------------------
 
-    // decimal unscaled = scaled * (decimal)scaleMultiplier;
-    $unscaled = bcmul($scaled, $scaleMultiplier, 0);
+        if (count($data) > count($result)) throw new Exception("decimal data buffer is ".count($data)." but result must fit into ".count($result)." bytes");
 
-    // UnscaledValue = (bscaled * scaleMultiplier) + new BigInteger(unscaled);
-    $UnscaledValue = gmp_add(gmp_mul($bscaled, $scaleMultiplier), $unscaled);
+        foreach($data as $i => $v) {
+            $result[$i] = $v;
+        }
 
-    // if($debug) {
-    //   echo("bscaled");
-    //   print_r([
-    //     'precision' => $precision,
-    //     'scale' => $scale,
-    //     '$d' => $d,
-    //     '$scaleMultiplier' => $scaleMultiplier,
-    //     '$bscaled' => $bscaled,
-    //     '$bscaledNum' => $bscaledNum,
-    //     '$scaled' => $scaled,
-    //     '$unscaled' => $unscaled,
-    //     '$UnscaledValue' => $UnscaledValue
-    //   ]);
-    // }
-
-    //
-    // Java: https://docs.oracle.com/javase/7/docs/api/java/math/BigInteger.html#toByteArray()
-    //
-    // Returns a byte array containing the two's-complement representation of this BigInteger. The byte array will be in big-endian byte-order: the most significant byte is in the zeroth element. The array will contain the minimum number of bytes required to represent this BigInteger, including at least one sign bit, which is (ceil((this.bitLength() + 1)/8)). (This representation is compatible with the (byte[]) constructor.)
-    //
-    // C#:   https://msdn.microsoft.com/en-us/library/system.numerics.biginteger.tobytearray(v=vs.110).aspx
-    //
-    //
-    //  value | C# | Java
-    //
-    // -1 | [1111 1111] | [1111 1111] - no difference, so maybe buffer size?
-    //
-
-    // byte[] result = AllocateResult();
-    $result = array_fill(0, $bufferSize = static::getBufferSize($precision), null); // from AllocateResult
-
-    // byte[] data = UnscaledValue.ToByteArray();
-    // $data = str_split($UnscaledValue);
-
-    $mbi = new \Math_BigInteger(gmp_strval($UnscaledValue));
-    $export = $mbi->toBytes(true);
-
-    // $export = gmp_export($UnscaledValue, 1, GMP_BIG_ENDIAN | GMP_MSW_FIRST);
-    $data = unpack('C*', $export);
-
-
-    $data = array_reverse($data);
-
-    // if($debug) {
-      // echo("EXPORT = ".bin2hex($export));
-      // // echo(bin2hex(implode('', $data)));
-      // echo("Data: ");
-      // print_r($data);
-      // echo("UnscaledValue: ");
-      // print_r($UnscaledValue);
-    // }
-
-    if (count($data) > count($result)) throw new Exception("decimal data buffer is ".count($data)." but result must fit into ".count($result)." bytes");
-
-    // Array.Copy(data, result, data.Length);
-    foreach($data as $i => $v) {
-      $result[$i] = $v; // chr($v); // TODO/QUESTION: ord or not?
+        if (gmp_sign($UnscaledValue) === -1) {
+            for ($i = count($data); $i < count($result); $i++) {
+                $result[$i] = 0xFF;
+            }
+        }
+        return array_reverse($result);
     }
 
-    // // DEBUG
-    // $result1 = $result;
+    /**
+     * Converts binary data to a string decimal
+     * @param [type]        $data   [description]
+     * @param SchemaElement $schema [description]
+     */
+    public static function BinaryDataToDecimal($data, SchemaElement $schema) {
+        $UnscaledValue = gmp_import($data, 1, GMP_BIG_ENDIAN | GMP_MSW_FIRST);
 
+        // Fix PHP 8.1+ deprecation warning by strictly checking the first byte character: $data[0]
+        if (strlen($data) > 0 && (ord($data[0]) & 0x80)) {
+            $bitLength = strlen($data) * 8;
+            $range = gmp_pow(2, $bitLength);
+            $UnscaledValue = gmp_sub($UnscaledValue, $range);
+        }
+        // ------------------------------------------------------
 
-    //if value is negative fill the remaining bytes with [1111 1111] i.e. negative flag bit (0xFF)
-    if (gmp_sign($UnscaledValue) === -1)
+        $precision = $schema->precision;
+        $scale = $schema->scale;
+        $scaleMultiplier = bcpow(10, $scale, 0);
+
+        list($ipScaled, $fpUnscaled) = \gmp_div_qr($UnscaledValue, $scaleMultiplier);
+        $ipScaledStr = gmp_strval($ipScaled);
+        $fpScaled = bcdiv(gmp_strval($fpUnscaled), gmp_strval($scaleMultiplier), $precision);
+        return bcadd($ipScaledStr, $fpScaled, $precision);
+    }
+
+    /**
+     * Gets buffer size enough to be able to hold the decimal number of a specific precision
+     * @param  int $precision [description]
+     * @return int            [length in bytes]
+     */
+    public static function GetBufferSize(int $precision): int
     {
-      // if($debug) {
-      //   // echo("GMP SIGN -1 ");
-      // }
-      for ($i = count($data); $i < count($result); $i++)
-      {
-        $result[$i] = 0xFF;
-      }
+        switch ($precision) {
+            case 1: case 2: return 1;
+            case 3: case 4: return 2;
+            case 5: case 6: return 3;
+            case 7: case 8: case 9: return 4;
+            case 10: case 11: return 5;
+            case 12: case 13: case 14: return 6;
+            case 15: case 16: return 7;
+            case 17: case 18: return 8;
+            case 19: case 20: case 21: return 9;
+            case 22: case 23: return 10;
+            case 24: case 25: case 26: return 11;
+            case 27: case 28: return 12;
+            default: return 16; // Default for higher precision
+        }
     }
-
-    $result = array_reverse($result);
-
-    // if($debug) {
-    //   print_r([
-    //     '$result1' => $result1,
-    //     '$result' => $result,
-    //     '$bufferSize' => $bufferSize,
-    //     'cnt' => count($result),
-    //     // 'array_filter($result)' => array_filter($result, function($byte) { return $byte !== null; }),
-    //   ]);
-    // }
-
-    // TESTING null filtering?
-    // $result = array_filter($result, function($byte) { return $byte !== null; });
-    // if($debug) {
-    //   echo("RESULT = ".bin2hex(implode('', $result)));
-    // }
-
-    return $result;
-  }
-
-  /**
-   * Converts binary data to a string decimal
-   * @param [type]        $data   [description]
-   * @param SchemaElement $schema [description]
-   */
-  public static function BinaryDataToDecimal($data, SchemaElement $schema) {
-    // $data = array_reverse(chunk_split($data, 1));
-    // $data = chunk_split($data, 1);
-
-    // $data = strrev($data);
-    // print_r($data);
-
-    // $data = unpack('C*', $data);
-    //
-    // print_r($data);
-    // // $data = array_reverse($data);
-    // //
-
-    // $data = strrev($data);
-    // $data = ~$data;
-
-
-    //
-    // This is just crazy.
-    //
-    $mbi = new \Math_BigInteger($data, -256);
-    $UnscaledValue = $mbi->value;
-
-    // $rawParsed = $raw->toString();
-    // // //
-    // echo("RAW PARSED");
-    // print_r($raw);
-
-
-    // $UnscaledValue = new \Math_BigInteger($data);
-    // $UnscaledValue = \gmp_import($data); // new BigInteger(data);
-
-    // print_r($UnscaledValue);
-
-    $precision = $schema->precision;
-    $scale = $schema->scale;
-
-    // BigInteger scaleMultiplier = BigInteger.Pow(10, Scale);
-    // $scaleMultiplier = \gmp_powm(10, $scale);
-    $scaleMultiplier = bcpow(10, $scale, 0); // (new \Math_BigInteger())->powMod();
-
-    // decimal ipScaled = (decimal)BigInteger.DivRem(UnscaledValue, scaleMultiplier, out BigInteger fpUnscaled);
-    // list($ipScaled, $fpUnscaled) = $UnscaledValue->divide($UnscaledValue);
-
-    // see https://www.php.net/manual/de/function.gmp-div-qr.php
-    list($ipScaled, $fpUnscaled) = \gmp_div_qr($UnscaledValue, $scaleMultiplier);
-    // $ipScaled = $res[0];
-    // $fpUnscaled = $res[1];
-
-    // $fpScaled = $fpUnscaled / $scaleMultiplier;
-    // $fpScaled = \gmp_div_q($fpUnscaled, $scaleMultiplier);
-
-    $ipScaled = gmp_strval($ipScaled);
-
-    $fpScaled = bcdiv(gmp_strval($fpUnscaled), gmp_strval($scaleMultiplier), $precision);
-
-    // DecimalValue = ipScaled + fpScaled;
-    $decimalValue = bcadd($ipScaled, $fpScaled, $precision); // $ipScaled + $fpScaled;
-
-    // print_r([
-    //   'data' => $data,
-    //   'UnscaledValue' => $UnscaledValue,
-    //   'decimalValue' => $decimalValue,
-    //   'ipScaled' => $ipScaled,
-    //   'fpScaled' => $fpScaled,
-    //   'fpUnscaled' => $fpUnscaled,
-    //   'scaleMultiplier' => $scaleMultiplier,
-    //   'out' => $decimalValue, // gmp_strval($decimalValue, 10),
-    // ]);
-
-    return $decimalValue;
-  }
-
-  /**
-   * Gets buffer size enough to be able to hold the decimal number of a specific precision
-   * @param  int $precision [description]
-   * @return int            [length in bytes]
-   */
-  public static function GetBufferSize(int $precision): int
-  {
-    //according to impala source: http://impala.io/doc/html/parquet-common_8h_source.html
-
-    $size = null;
-
-    switch ($precision)
-    {
-      case 1:
-      case 2:
-        $size = 1;
-        break;
-      case 3:
-      case 4:
-        $size = 2;
-        break;
-      case 5:
-      case 6:
-        $size = 3;
-        break;
-      case 7:
-      case 8:
-      case 9:
-        $size = 4;
-        break;
-      case 10:
-      case 11:
-        $size = 5;
-        break;
-      case 12:
-      case 13:
-      case 14:
-        $size = 6;
-        break;
-      case 15:
-      case 16:
-        $size = 7;
-        break;
-      case 17:
-      case 18:
-        $size = 8;
-        break;
-      case 19:
-      case 20:
-      case 21:
-        $size = 9;
-        break;
-      case 22:
-      case 23:
-        $size = 10;
-        break;
-      case 24:
-      case 25:
-      case 26:
-        $size = 11;
-        break;
-      case 27:
-      case 28:
-        $size = 12;
-        break;
-      case 29:
-      case 30:
-      case 31:
-        $size = 13;
-        break;
-      case 32:
-      case 33:
-        $size = 14;
-        break;
-      case 34:
-      case 35:
-        $size = 15;
-        break;
-      case 36:
-      case 37:
-      case 38:
-        $size = 16;
-        break;
-      default:
-        $size = 16;
-        break;
-    }
-
-    return $size;
-  }
 }

--- a/tests/values/primitives/BigDecimalTest.php
+++ b/tests/values/primitives/BigDecimalTest.php
@@ -1,18 +1,62 @@
 <?php
+
 declare(strict_types=1);
+
 namespace codename\parquet\tests\values\primitives;
 
+use codename\parquet\format\SchemaElement;
 use codename\parquet\tests\TestBase;
 
 use codename\parquet\values\primitives\BigDecimal;
 
 final class BigDecimalTest extends TestBase
 {
-  /**
-   * [testValidButMassiveBigDecimal description]
-   */
-  public function testValidButMassiveBigDecimal(): void {
-    $this->expectNotToPerformAssertions();
-    $bd = BigDecimal::DecimalToBinary("83086059037282.54", 38, 16);
-  }
+    /**
+     * [testValidButMassiveBigDecimal description]
+     */
+    public function testValidButMassiveBigDecimal(): void
+    {
+        $bd = BigDecimal::DecimalToBinary("83086059037282.54", 38, 16);
+        $this->assertSame([null, null, null, 10, 124, 167, 197, 167, 189, 132, 151, 196, 163, 171, 128, 0], $bd);
+    }
+
+    /**
+     * Test round-trip conversion for positive, negative, and zero values.
+     */
+    public function testDecimalToBinaryAndBack(): void
+    {
+        // Test cases: [string value, precision, scale]
+        $testValues = [
+            ["83086059037282.54", 38, 16],
+            ["-83086059037282.54", 38, 16],
+            ["0.00", 38, 16],
+            ["1.00", 9, 2],
+            ["-1.00", 9, 2]
+        ];
+
+        foreach ($testValues as [$originalValue, $precision, $scale]) {
+            // Instantiate the real SchemaElement using its array-based constructor
+            $schema = new SchemaElement([
+                'precision' => $precision,
+                'scale' => $scale,
+                'name' => 'test_decimal_field'
+            ]);
+
+            // 1. Convert string decimal to binary byte array representation
+            $binaryArray = BigDecimal::DecimalToBinary($originalValue, $precision, $scale);
+
+            // 2. Pack the byte array back into a binary string for decoding
+            // Filter out null placeholders to match binary stream input format
+            $filteredBytes = array_filter($binaryArray, function ($byte) {
+                return $byte !== null;
+            });
+            $binaryData = pack('C*', ...$filteredBytes);
+
+            // 3. Decode binary data back to string decimal representation
+            $decodedValue = BigDecimal::BinaryDataToDecimal($binaryData, $schema);
+
+            // 4. Assert BCMath-compliant equal values (ignoring trailing zeros after scale conversion)
+            $this->assertSame(0, bccomp($originalValue, $decodedValue, $scale), "Failed round-trip for value: {$originalValue}");
+        }
+    }
 }


### PR DESCRIPTION
### Description

Closes https://github.com/codename-hub/php-parquet/issues/31

This Pull Request removes the abandoned `pear/math_biginteger` dependency by refactoring the `BigDecimal` primitive class to fully rely on PHP's native **GMP** (GNU Multiple Precision) extension. 

### Changes Proposed
- **`composer.json`**: Dropped `pear/math_biginteger` requirement.
- **`BigDecimal`**: 
  - Refactored `DecimalToBinary()` using `gmp_export()` with explicit bit-length calculation and two's complement binary construction for negative numbers.
  - Refactored `BinaryDataToDecimal()` using `gmp_import()` with manual sign-bit reconstruction for safe reverse mapping.
- **`BigDecimalTest`**: Added and extended `BigDecimalTest` to ensure that the newly refactored GMP implementation produces identical results compared to the legacy `Math_BigInteger` code.


### Verification Results
All PHPUnit assertions pass successfully. Tested with large arbitrary-precision values (`83086059037282.54`), including negative scales and zeros, with no regressions or unexpected output.
